### PR TITLE
Subscribe: atomic initialisation of e.listeners

### DIFF
--- a/mutex/bus.go
+++ b/mutex/bus.go
@@ -64,18 +64,8 @@ func (e *Bus) Subscribe(topic string, listener gobus.EventListener) {
 	}
 	var list []gobus.EventListener
 
-	//read current map status
-	/*
-		in the same lock period
-		* check if map is empty
-		* if not empty, get requested id
-	*/
-	e.listenerMutex.RLock()
-	empty := e.listeners == nil
-	e.listenerMutex.RUnlock()
-
 	e.listenerMutex.Lock()
-	if empty {
+	if e.listeners == nil {
 		e.listeners = make(map[uint32][]gobus.EventListener)
 	}
 	id := strTouint32(topic)


### PR DESCRIPTION
First, thanks for great idea. I need something similar in one project.

Reasons for this change:

- One lock operation is just faster than two. Since you take full lock anyway, not under condition.
- As `sync.RWMutex` does not provide "escalate read to full lock", it was possible for multiple concurrent subscribers to observe `listeners==nil` and then overwrite each other, last wins.

```
(1)Subscribe() RLock -> empty=true -> RUnlock
(2)Subscribe() RLock -> empty=true -> RUnlock
(1)Lock acquired -> ...
(2)Lock wait ...
(1)                 ... (1)empty==true -> listeners = make() -> Unlock
(2)          ... Lock acquired -> (2)empty==true -> listeners = make (! overwrite) -> Unlock
```
